### PR TITLE
Add support for molecule generated keypair and keyfile, if omitted in…

### DIFF
--- a/molecule/util.py
+++ b/molecule/util.py
@@ -204,8 +204,10 @@ def check_ssh_availability(hostip, user, timeout, sshkey_filename):
         time.sleep(timeout)
         return False
 
+
 def generated_ssh_key_file_location():
     return GENERATED_SSH_KEY_LOCATION
+
 
 def generate_temp_ssh_key():
     fileloc = generated_ssh_key_file_location()

--- a/molecule/util.py
+++ b/molecule/util.py
@@ -202,6 +202,36 @@ def check_ssh_availability(hostip, user, timeout):
         time.sleep(timeout)
         return False
 
+ 
+def generate_temp_ssh_key():
+    # allow python to access the home directory
+    home = expanduser("~")
+    fileloc = home + "/.ssh/id_rsa"
+
+    # create the private key
+    k = paramiko.RSAKey.generate(2048)
+    k.write_private_key_file(fileloc)
+
+    # write the public key too
+    pub = paramiko.RSAKey(filename=fileloc)
+    with open("%s.pub" % fileloc, 'w') as f:
+        f.write("%s %s" % (pub.get_name(), pub.get_base64()))
+
+    return fileloc
+
+
+def remove_temp_ssh_key():
+    home = expanduser("~")
+    fileloc = home + "/.ssh/id_rsa"
+    os.remove(fileloc)
+    os.remove(fileloc + ".pub")
+
+
+def generate_random_keypair_name(prefix, length):
+    import random
+    r = "".join([random.choice('abcdef0123456789') for n in xrange(length)])
+    return prefix + "_" + r
+
 
 def debug(title, data):
     """

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -141,13 +141,17 @@ def test_debug(capsys):
 
 
 def test_generate_temp_ssh_key():
-    from os.path import expanduser
-    home = expanduser("~")
-    fileloc = home + "/.ssh/id_rsa"
+    fileloc = '/tmp/molecule_rsa'
 
     util.generate_temp_ssh_key()
     assert os.path.isfile(fileloc)
     assert os.path.isfile(fileloc + '.pub')
+
+
+def test_generate_random_keypair_name():
+    import re
+    result_keypair = util.generate_random_keypair_name('molecule', 10)
+    assert re.match(r'molecule-[0-9a-fA-F]+', result_keypair)
 
 
 def test_sysexit():

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -140,6 +140,16 @@ def test_debug(capsys):
     assert expected_title == result_title
 
 
+def test_generate_temp_ssh_key():
+    from os.path import expanduser
+    home = expanduser("~")
+    fileloc = home + "/.ssh/id_rsa"
+
+    util.generate_temp_ssh_key()
+    assert os.path.isfile(fileloc)
+    assert os.path.isfile(fileloc + '.pub')
+
+
 def test_sysexit():
     with pytest.raises(SystemExit) as e:
         util.sysexit()

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -148,6 +148,14 @@ def test_generate_temp_ssh_key():
     assert os.path.isfile(fileloc + '.pub')
 
 
+def test_delete_temp_ssh_key():
+    fileloc = '/tmp/molecule_rsa'
+
+    util.remove_temp_ssh_key()
+    assert not os.path.isfile(fileloc)
+    assert not os.path.isfile(fileloc + '.pub')
+
+
 def test_generate_random_keypair_name():
     import re
     result_keypair = util.generate_random_keypair_name('molecule', 10)


### PR DESCRIPTION
… the molecule.yml

This change is so that molecule can generate an ssh keyfile and openstack keypair when not specified in the molecule.yml
The reason for this change, is we plan to use this mostly in continuous integration systems. We don't really care about persisting a key or keypair since the instance running molecule will be destroyed once molecule is finished.
The changes make sure that if ~/.ssh/id_rsa exists already, that we will not delete it. Molecule only deletes the keypair and keyfiles that it creates and should not do so if they are explictly specified.
